### PR TITLE
Fix filepath for Windows

### DIFF
--- a/main.js
+++ b/main.js
@@ -255,8 +255,9 @@ function readFile(filepath) {
       return;
     }
 
-    let position = filepath.lastIndexOf("/");
-    global.filepath = filepath.substring(0, position+1);
+    var safeFilepath = filepath.replace('/\\/g', '/');
+    let position = safeFilepath.lastIndexOf("\\");
+    global.filepath = safeFilepath.substring(0, position+1);
     mainWindow.setTitle(filepath);
     mainWindow.webContents.send('openFile', data);
   });

--- a/main.js
+++ b/main.js
@@ -255,8 +255,8 @@ function readFile(filepath) {
       return;
     }
 
-    var safeFilepath = filepath.replace('/\\/g', '/');
-    let position = safeFilepath.lastIndexOf("\\");
+    var safeFilepath = filepath.replace(/\\/g, '/');
+    let position = safeFilepath.lastIndexOf("/");
     global.filepath = safeFilepath.substring(0, position+1);
     mainWindow.setTitle(filepath);
     mainWindow.webContents.send('openFile', data);


### PR DESCRIPTION
Pretty simple fix for #8. Since Windows uses backslashes for filepaths `filepath.lastIndexOf("/")` is `-1` which makes `filepath.substring(0, position+1);` kill the whole string. By replacing `\` with `/` first it's safe, no matter which slashes are used _(probably...)_